### PR TITLE
Use paste for insert snippet

### DIFF
--- a/autoload/tsnip.vim
+++ b/autoload/tsnip.vim
@@ -4,11 +4,18 @@ endfunction
 
 function! tsnip#remove_suffix_word(word) abort
   let len = len(a:word)
+  let [lnum, col] = getcurpos()[:1]
   let lnum = getcurpos()[1]
   let col = getcurpos()[2]
   let line = getline('.')
 
-  let line = substitute(line, a:word . '$', '', '')
-  call setline(lnum, line)
+  if col == len(a:word) + 1
+    " Note: Result of `col` come to -1 when only `a:word` in left of cursor.
+    let before = ''
+  else
+    let before = line[0:col - len(a:word) - 2]
+  endif
+  let after = line[col - 1:]
+  call setline(lnum, before .. after)
   call cursor(lnum, col - len)
 endfunction

--- a/denops/@ddc-sources/tsnip.ts
+++ b/denops/@ddc-sources/tsnip.ts
@@ -2,8 +2,8 @@ import {
   BaseSource,
   GatherArguments,
   OnCompleteDoneArguments,
-} from "https://deno.land/x/ddc_vim@v3.1.0/base/source.ts";
-import { Item } from "https://deno.land/x/ddc_vim@v3.1.0/types.ts";
+} from "https://deno.land/x/ddc_vim@v3.2.0/base/source.ts";
+import { Item } from "https://deno.land/x/ddc_vim@v3.2.0/types.ts";
 
 export type CompletionMetadata = {
   word: string;

--- a/denops/tsnip/main.ts
+++ b/denops/tsnip/main.ts
@@ -158,6 +158,7 @@ const insertSnippet = async (denops: Denops) => {
     // re-format tab for indent included snippets
     await denops.cmd(`${pos.line},${pos.line + result.length - 1}retab!`);
     if (hasCursor) {
+      await denops.call("cursor", [pos.line, pos.col]);
       await denops.call("search", CURSOR_MARKER);
       await denops.cmd('normal! "_d' + CURSOR_MARKER.length + "l");
       await denops.cmd("startinsert");

--- a/denops/tsnip/main.ts
+++ b/denops/tsnip/main.ts
@@ -29,8 +29,8 @@ let fileName: string;
 let fileType: string;
 let cwd: string;
 let currentLine: string;
-let beforeCursor: string;
-let afterCursor: string;
+let beforeCursorText: string;
+let afterCursorText: string;
 let useNui: boolean;
 let modules: {
   [fileType: string]: {
@@ -91,7 +91,7 @@ const renderPreview = async (
   denops: Denops,
   inputs: Inputs,
 ): Promise<void> => {
-  const preview = beforeCursor + renderSnippet(snippet, inputs) + afterCursor;
+  const preview = beforeCursorText.trimStart() + renderSnippet(snippet, inputs) + afterCursorText;
   const lines = preview.replace(CURSOR_MARKER, "|").split("\n");
 
   lastExtMarkId = await denops.call(
@@ -223,16 +223,16 @@ export const main = async (denops: Denops): Promise<void> => {
       currentLine = await denops.call("getline", ".") as string;
 
       if (mode === "i") {
-        beforeCursor = currentLine.slice(
+        beforeCursorText = currentLine.slice(
           0,
           new TextDecoder().decode(
             new TextEncoder().encode(currentLine).slice(0, pos.col - 1),
           ).length,
         );
-        afterCursor = currentLine.slice(beforeCursor.length);
+        afterCursorText = currentLine.slice(beforeCursorText.length);
       } else {
-        beforeCursor = "";
-        afterCursor = "";
+        beforeCursorText = "";
+        afterCursorText = "";
       }
 
       if (snippet.params.length > 0) {

--- a/denops/tsnip/main.ts
+++ b/denops/tsnip/main.ts
@@ -1,14 +1,14 @@
-import { exists } from "https://deno.land/std@0.123.0/fs/mod.ts";
-import { toFileUrl } from "https://deno.land/std@0.120.0/path/mod.ts";
-import type { Denops } from "https://deno.land/x/denops_std@v2.4.0/mod.ts";
-import * as autocmd from "https://deno.land/x/denops_std@v2.4.0/autocmd/mod.ts";
-import * as variable from "https://deno.land/x/denops_std@v2.4.0/variable/mod.ts";
-import * as helper from "https://deno.land/x/denops_std@v2.4.0/helper/mod.ts";
-import * as op from "https://deno.land/x/denops_std@v2.4.0/option/mod.ts";
+import { exists } from "https://deno.land/std@0.165.0/fs/mod.ts";
+import { toFileUrl } from "https://deno.land/std@0.165.0/path/mod.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v3.9.3/mod.ts";
+import * as autocmd from "https://deno.land/x/denops_std@v3.9.3/autocmd/mod.ts";
+import * as variable from "https://deno.land/x/denops_std@v3.9.3/variable/mod.ts";
+import * as helper from "https://deno.land/x/denops_std@v3.9.3/helper/mod.ts";
+import * as op from "https://deno.land/x/denops_std@v3.9.3/option/mod.ts";
 import {
-  ensureString,
+  assertString,
   isBoolean,
-} from "https://deno.land/x/unknownutil@v1.1.4/mod.ts";
+} from "https://deno.land/x/unknownutil@v2.1.0/mod.ts";
 
 import { Inputs, Snippet } from "./types.ts";
 
@@ -162,7 +162,7 @@ export const main = async (denops: Denops): Promise<void> => {
 
   denops.dispatcher = {
     execute: async (snippetName: unknown): Promise<void> => {
-      ensureString(snippetName);
+      assertString(snippetName);
 
       const module = await loadSnippetModule(denops, path);
       snippet = module[snippetName];
@@ -198,8 +198,8 @@ export const main = async (denops: Denops): Promise<void> => {
       }
     },
     submit: async (name: unknown, input: unknown): Promise<void> => {
-      ensureString(name);
-      ensureString(input);
+      assertString(name);
+      assertString(input);
 
       if (lastExtMarkId != null) {
         await deletePreview(denops);
@@ -247,8 +247,8 @@ export const main = async (denops: Denops): Promise<void> => {
       }
     },
     changed: async (name: unknown, input: unknown): Promise<void> => {
-      ensureString(name);
-      ensureString(input);
+      assertString(name);
+      assertString(input);
 
       if (lastExtMarkId != null) {
         await deletePreview(denops);

--- a/denops/tsnip/main.ts
+++ b/denops/tsnip/main.ts
@@ -91,8 +91,12 @@ const renderPreview = async (
   denops: Denops,
   inputs: Inputs,
 ): Promise<void> => {
-  const preview = beforeCursorText.trimStart() + renderSnippet(snippet, inputs) + afterCursorText;
-  const lines = preview.replace(CURSOR_MARKER, "|").split("\n");
+  const indent = beforeCursorText.replace(/\S.*$/, "");
+  const preview = beforeCursorText.trimStart() +
+    renderSnippet(snippet, inputs) + afterCursorText;
+  const lines = preview.replace(CURSOR_MARKER, "|")
+    .split("\n")
+    .map((line) => indent + line);
 
   lastExtMarkId = await denops.call(
     "nvim_buf_set_extmark",

--- a/denops/tsnip/types.ts
+++ b/denops/tsnip/types.ts
@@ -10,15 +10,16 @@ export type Inputs = {
   [key: string]: { text: string | undefined } | undefined;
 };
 
-export type ExtraInputs = {
+export type Context = {
   fileName: { text: string };
   fileType: { text: string };
   cwd: { text: string };
+  postCursor: string;
 };
 
 export type Snippet = {
   name?: string;
   text?: string;
   params: Array<Param>;
-  render: (inputs: Inputs, extraInputs: ExtraInputs) => string;
+  render: (inputs: Inputs, extraInputs: Context) => string;
 };

--- a/doc/tsnip_nvim.txt
+++ b/doc/tsnip_nvim.txt
@@ -80,16 +80,17 @@ render:
 
 
 ==============================================================================
-RENDER_EXTRA_INPUTS                              *tsnip-render-extra-inputs*
+RENDER_CONTEXT                                        *tsnip-render-context*
 
-The type of ExtraInput passed as the second argument of the render function.
+The type of Context passed as the second argument of the render function.
 
 TypeDefinition:
 >
-   type ExtraInputs = {
+   type Context = {
      fileName: { text: string };
      fileType: { text: string };
      cwd: { text: string };
+     postCursor: string;
    };
 <
 
@@ -100,7 +101,16 @@ Example:
      render: (_, { fileName }) => `${fileName}`
    }
 <
+postCursor is unique text, cursor will jump to there and start insert mode.
 
+Example:
+>
+   const cursorSnippet: Snippet = {
+     params: [],
+     render: (_, { postCursor }) => `console.log(${postCursor})`
+   }
+<
+above snippet will expand to `console.log(|)`. (cursor jump to `|`)
 
 ==============================================================================
 EXAMPLE                                         *tsnip-example*


### PR DESCRIPTION
スニペットの挿入処理にVimのpaste機能を使用するように変更します。

挿入モードで補完を使用してスニペットを展開した後挿入モードに戻るようになります。この挙動の変更に対してオプションが必要であれば付けます。